### PR TITLE
Use theme colours throughout the app

### DIFF
--- a/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/components/LoadingAnimation.kt
+++ b/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/components/LoadingAnimation.kt
@@ -25,10 +25,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import org.bitcoindevkit.devkitwallet.presentation.theme.DevkitWalletColors
 
 @Composable
 fun LoadingAnimation(
-    circleColor: Color = Color(0xffE9C46A),
+    circleColor: Color = DevkitWalletColors.accent1,
     circleSize: Dp = 21.dp,
     animationDelay: Int = 800,
     initialAlpha: Float = 0.3f,

--- a/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/components/TransactionCards.kt
+++ b/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/components/TransactionCards.kt
@@ -100,7 +100,7 @@ fun PendingTransactionCard(details: TxDetails, navController: NavController) {
                 .padding(top = 16.dp, end = 16.dp)
                 .size(size = 24.dp)
                 .clip(shape = CircleShape)
-                .background(Color(0xffE9C46A))
+                .background(DevkitWalletColors.accent1)
                 .align(Alignment.Top)
         )
     }

--- a/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/screens/intro/OnboardingScreen.kt
+++ b/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/screens/intro/OnboardingScreen.kt
@@ -99,7 +99,7 @@ fun OnboardingScreen(onFinishOnboarding: () -> Unit) {
                     .size(size = 16.dp)
                     .clip(shape = CircleShape)
                     .background(
-                        if (currentIndex == 1) Color(0xffE9C46A) else Color(0xffE9C46A).copy(alpha = 0.3f)
+                        if (currentIndex == 1) DevkitWalletColors.accent1 else DevkitWalletColors.accent1.copy(alpha = 0.3f)
                     )
             )
             Box(
@@ -108,7 +108,7 @@ fun OnboardingScreen(onFinishOnboarding: () -> Unit) {
                     .size(size = 16.dp)
                     .clip(shape = CircleShape)
                     .background(
-                        if (currentIndex == 2) Color(0xffE9C46A) else Color(0xffE9C46A).copy(alpha = 0.3f)
+                        if (currentIndex == 2) DevkitWalletColors.accent1 else DevkitWalletColors.accent1.copy(alpha = 0.3f)
                     )
             )
             Box(
@@ -117,7 +117,7 @@ fun OnboardingScreen(onFinishOnboarding: () -> Unit) {
                     .size(size = 16.dp)
                     .clip(shape = CircleShape)
                     .background(
-                        if (currentIndex == 3) Color(0xffE9C46A) else Color(0xffE9C46A).copy(alpha = 0.3f)
+                        if (currentIndex == 3) DevkitWalletColors.accent1 else DevkitWalletColors.accent1.copy(alpha = 0.3f)
                     )
             )
         }

--- a/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/screens/wallet/ReceiveScreen.kt
+++ b/app/src/main/java/org/bitcoindevkit/devkitwallet/presentation/ui/screens/wallet/ReceiveScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -63,6 +64,7 @@ import org.bitcoindevkit.devkitwallet.presentation.theme.standardText
 import org.bitcoindevkit.devkitwallet.presentation.ui.components.SecondaryScreensAppBar
 import org.bitcoindevkit.devkitwallet.presentation.viewmodels.mvi.ReceiveScreenAction
 import org.bitcoindevkit.devkitwallet.presentation.viewmodels.mvi.ReceiveScreenState
+import androidx.core.graphics.set
 
 private const val TAG = "ReceiveScreen"
 
@@ -193,7 +195,8 @@ private fun addressToQR(address: String): ImageBitmap? {
         for (x in 0 until 1000) {
             for (y in 0 until 1000) {
                 // DevkitWalletColors.primaryDark for dark and DevkitWalletColors.white for light
-                bitMap.setPixel(x, y, if (bitMatrix[x, y]) 0xff203b46.toInt() else 0xffffffff.toInt())
+                bitMap[x, y] =
+                    if (bitMatrix[x, y]) DevkitWalletColors.primaryDark.toArgb() else DevkitWalletColors.white.toArgb()
             }
         }
         return bitMap.asImageBitmap()


### PR DESCRIPTION
Cleans up the hard coded colours across the repo to reference the theme types instead. Related issue: https://github.com/bitcoindevkit/devkit-wallet/issues/16

![qr code working](https://github.com/user-attachments/assets/0f3280f1-f54f-455d-8f7e-71085d9b0e0b)
